### PR TITLE
Guard basket grand total against stale /quote responses

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -542,6 +542,9 @@ function addToBasket() {
 }
 
 async function renderBasket() {
+    const quoteRequestToken = (state.quoteRequestToken || 0) + 1;
+    state.quoteRequestToken = quoteRequestToken;
+
     const body = document.getElementById('basketBody');
     body.innerHTML = '';
     let total = 0;
@@ -573,6 +576,11 @@ async function renderBasket() {
             rate: it.rate
         }));
         const quote = await apiClient.getQuote(lineItems, state.margin);
+
+        if (quoteRequestToken !== state.quoteRequestToken) {
+            return;
+        }
+
         document.getElementById('grandTotal').innerText = fmt(quote.payout);
     } catch (err) {
         console.warn('Quote API fallback to client calc:', err.message);


### PR DESCRIPTION
### Motivation
- Prevent stale asynchronous `/quote` responses from overwriting the displayed basket grand total when the basket or margin changes rapidly.

### Description
- Added a per-render `quoteRequestToken` in `renderBasket()` and a guard after `await apiClient.getQuote(...)` that only updates `#grandTotal` when the response token matches the latest token, implemented in `index.htm`.

### Testing
- Ran `git diff --check` on the change which returned no issues and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1bb2583b4832d8a467cdd77e9ccb0)